### PR TITLE
Swagger docs

### DIFF
--- a/docs/api/spec/query-api.yaml
+++ b/docs/api/spec/query-api.yaml
@@ -1,8 +1,9 @@
+# The openapi specification for the like API
 openapi: 3.0.0
 info:
-  title: Treetracker Wallet API
+  title: Treetracker Like API
   contact: {}
-  version: '1.28.0'
+  version: '1.0.0'
 servers:
   - url: https://localhost:3010
     variables:
@@ -11,13 +12,20 @@ servers:
         enum:
           - dev     # Development server
           - test    # Test server
+security:
+  - OAuth2:
+      - read
+      - write
+      - admin
+
 paths:
   '/types/{type_uuid}/things/{object_uuid}':
-    post:
+    get:
       tags:
         - Like / unlike a likable object and get the like counts
       summary: Get the like count of a likable object
-      description: 'Get the like count of a likable object'
+      description: Get the like count of a likable object, get like number is open for everyone, no need token
+      security: []
       parameters:
         - name: type_uuid
           description: 'ID of specific token to retrieve'
@@ -35,13 +43,6 @@ paths:
             type: string
             format: uuid
             example: '550e8400-e29b-41d4-a716-196655440000'
-      requestBody:
-        description: 'User OIDC access token'
-        content:
-          application/json: 
-            example: 
-              access_token: '{{ACCESS_TOKEN}}'
-        required: true
       responses:
         '200':
           description: 'Successfully retrieve the object'
@@ -59,7 +60,9 @@ paths:
       tags:
         - Like / unlike a likable object and get the like counts
       summary: Like a likable object
-      description: 'Like a likable object'
+      description: 'Like a likable object, liking things needs user token (logged in), and write permission to this resource, we will get the user id from the token, and write coresponding data in db'
+      security:
+        - OAuth2: ["write"]
       parameters:
         - name: type_uuid
           description: 'ID of specific token to retrieve'
@@ -77,13 +80,6 @@ paths:
             type: string
             format: uuid
             example: '550e8400-e29b-41d4-a716-196655440000'
-      requestBody:
-        description: 'User OIDC access token'
-        content:
-          application/json: 
-            example: 
-              access_token: '{{ACCESS_TOKEN}}'
-        required: true
       responses:
         '201':
           description: 'Successfully like the object response'
@@ -101,7 +97,9 @@ paths:
       tags:
         - Like / unlike a likable object and get the like counts
       summary: Unlike a likable object
-      description: 'Unlike a likable object'
+      description: 'Unlike a likable object, liking things needs user token (logged in), and write permission to this resource, we will get the user id from the token, and write coresponding data in db'
+      security:
+        - OAuth2: ["write"]
       parameters:
         - name: type_uuid
           description: 'ID of specific token to retrieve'
@@ -119,13 +117,6 @@ paths:
             type: string
             format: uuid
             example: '550e8400-e29b-41d4-a716-196655440000'
-      requestBody:
-        description: 'User OIDC access token'
-        content:
-          application/json: 
-            example: 
-              access_token: '{{ACCESS_TOKEN}}'
-        required: true
       responses:
         '201':
           description: 'Successfully unlike the object response'
@@ -143,7 +134,9 @@ paths:
       tags:
         - Types info and manipulation
       summary: Get types name and id
-      description: 'Get types name and id'
+      description: 'Get types name and id, require `admin` scope of the autho0'
+      security:
+        - OAuth2: [admin]
       responses:
         '200':
           description: 'Successfully retrieve types info'
@@ -162,14 +155,15 @@ paths:
       tags:
         - Types info and manipulation
       summary: Create a new type in the database
-      description: 'Create a new type in the database'
+      description: 'Create a new type in the database, require `admin` scope of OAuth2 permission'
+      security:
+        - OAuth2: [admin]
       requestBody:
         description: 'Name of new type'
         content:
-          application/json: 
-            example: 
+          application/json:
+            example:
               name: 'trees'
-              access_token: '{{ACCESS_TOKEN}}'
         required: true
       responses:
         '201':
@@ -185,8 +179,10 @@ paths:
     patch:
       tags:
         - Types info and manipulation
-      summary: Create a new type in the database
-      description: 'Create a new type in the database'
+      summary: Modify existing type in the database
+      description: 'Modify exisiting type in the database'
+      security:
+        - OAuth2: [admin]
       parameters:
         - name: type_uuid
           description: 'ID of specific token to retrieve'
@@ -197,12 +193,11 @@ paths:
             format: uuid
             example: '550e8400-e29b-41d4-a716-446655440000'
       requestBody:
-        description: 'Name of new type'
+        description: 'Name of type'
         content:
-          application/json: 
+          application/json:
             example:
               name: 'above_the_ground_trees'
-              access_token: '{{ACCESS_TOKEN}}'
         required: true
       responses:
         '200':
@@ -217,19 +212,13 @@ paths:
           $ref: '#/components/responses/NotfoundError'
       deprecated: false
 
-  '/user/likes':
-    post:
+  '/user/:user_id/types/:type_id':
+    get:
       tags:
-        - Get user like / unlike activities
+        - Get user like / unlike activities on a type
       summary: Get user like / unlike activities
-      description: 'Get user like / unlike activities'
-      requestBody:
-        description: 'User OIDC access token'
-        content:
-          application/json: 
-            example: 
-              access_token: '{{ACCESS_TOKEN}}'
-        required: true
+      description: 'Get user like / unlike activities, this api is open for everyone, so no token and access control needed'
+      security: []
       responses:
         '200':
           description: 'Successfully retrieve user activities'
@@ -243,8 +232,19 @@ paths:
         '404':
           $ref: '#/components/responses/NotfoundError'
       deprecated: false
-  
+
 components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://dev-k8s.treetracker.org/keycloak/realm/treetracker/oauth/authorize
+          tokenUrl: https://dev-k8s.treetracker.org/keycloak/realm/treetracker/oauth/token
+          scopes:
+            read: Grants read access
+            write: Grants write access
+            admin: Grants access to admin operations
   responses:
     MissingParameterError:
       description: 'Missing request parameters'
@@ -267,16 +267,6 @@ components:
           example:
             code: 404
             message: 'User not found'
-  parameters:
-    accessToken:
-      name: access_token
-      in: header
-      description: 'Specifies the user information, mostly the user id'
-      required: true
-      style: simple
-      schema:
-        type: string
-        example: {{ACCESS_TOKEN}}
   schemas:
     likableObject:
       title: Likeable object
@@ -295,3 +285,4 @@ components:
         numLikes:
           type: number
           example: 10
+

--- a/docs/api/spec/query-api.yaml
+++ b/docs/api/spec/query-api.yaml
@@ -1,0 +1,208 @@
+openapi: 3.0.0
+info:
+  title: Treetracker Wallet API
+  contact: {}
+  version: '1.28.0'
+servers:
+  - url: https://localhost:3010
+    variables:
+      environment:
+        default: dev
+        enum:
+          - dev     # Development server
+          - test    # Test server
+paths:
+  '/{object_type}/{object_uuid}/like':
+    post:
+      tags:
+        - Like / unlike a likable object
+      summary: Like a likable object
+      description: 'Like a likable object'
+      parameters:
+        - name: object_type
+          description: 'ID of specific token to retrieve'
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: trees
+        - name: object_uuid
+          description: 'ID of specific token to retrieve'
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 186734
+      requestBody:
+        description: 'User OIDC access token'
+        content:
+          text/plain: 
+            example: '{{ACCESS_TOKEN}}'
+        required: true
+      responses:
+        '201':
+          description: 'Successfully like the object response'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/likableObject'
+        '422':
+          description: 'Missing request parameters'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/likableObject'
+              example:
+                code: 422
+                message: 'object_type is not allowed to be empty'
+      deprecated: false
+  
+  '/{object_type}/{object_uuid}/unlike':
+    post:
+      tags:
+        - Like / unlike a likable object
+      summary: Unlike a likable object
+      description: 'Unlike a likable object'
+      parameters:
+        - name: object_type
+          description: 'ID of specific token to retrieve'
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: trees
+        - name: object_uuid
+          description: 'ID of specific token to retrieve'
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 186734
+      requestBody:
+        description: 'User OIDC access token'
+        content:
+          text/plain: 
+            example: '{{ACCESS_TOKEN}}'
+        required: true
+      responses:
+        '201':
+          description: 'Successfully like the object response'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/likableObject'
+        '422':
+          description: 'Missing request parameters'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/likableObject'
+              example:
+                code: 422
+                message: 'object_type is not allowed to be empty'
+      deprecated: false
+      
+  '/{object_type}/{object_uuid}':
+    get:
+      tags:
+        - Get info on a likable object
+      summary: Get info on a likable object
+      description: 'Get info on a likable object'
+      parameters:
+        - name: object_type
+          description: 'ID of specific token to retrieve'
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: trees
+        - name: object_uuid
+          description: 'ID of specific token to retrieve'
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 186734
+      responses:
+        '200':
+          description: 'Successfully like the object response'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/likableObject'
+        '422':
+          description: 'Missing request parameters'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/likableObject'
+              example:
+                code: 422
+                message: 'object_type is not allowed to be empty'
+      deprecated: false
+
+  '/user/likes':
+    post:
+      tags:
+        - Get user like / unlike activities
+      summary: Get user like / unlike activities
+      description: 'Get user like / unlike activities'
+      requestBody:
+        description: 'User OIDC access token'
+        content:
+          text/plain: 
+            example: '{{ACCESS_TOKEN}}'
+        required: true
+      responses:
+        '200':
+          description: 'Successfully retrieve user activities'
+          content:
+            application/json:
+              example:
+                species: [1,2]
+                trees: [186735, 186734]
+        '404':
+          description: 'User not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/likableObject'
+              example:
+                code: 404
+                message: 'User not found'
+      deprecated: false
+components:
+  parameters:
+    accessToken:
+      name: access_token
+      in: header
+      description: 'Specifies the user information, mostly the user id'
+      required: true
+      style: simple
+      schema:
+        type: string
+        example: {{ACCESS_TOKEN}}
+  schemas:
+    likableObject:
+      title: Likeable object
+      required:
+        - objectType
+        - objectId
+        - numLikes
+      type: object
+      properties:
+        objectType:
+          type: string
+          example: trees
+        objectId:
+          type: string
+          example: 186734
+        numLikes:
+          type: number
+          example: 10

--- a/docs/api/spec/query-api.yaml
+++ b/docs/api/spec/query-api.yaml
@@ -210,7 +210,7 @@ paths:
           content:
             application/json:
               example:
-                5: 'above_the_ground_trees'
+                550e8400-e29b-41d4-a716-446655440019: 'above_the_ground_trees'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '404':

--- a/docs/api/spec/query-api.yaml
+++ b/docs/api/spec/query-api.yaml
@@ -12,37 +12,80 @@ servers:
           - dev     # Development server
           - test    # Test server
 paths:
-  '/like/types/{type_id}/things/{object_id}':
-    get:
+  '/types/{type_uuid}/things/{object_uuid}':
+    post:
       tags:
-        - Like / unlike a likable object
+        - Like / unlike a likable object and get the like counts
+      summary: Get the like count of a likable object
+      description: 'Get the like count of a likable object'
+      parameters:
+        - name: type_uuid
+          description: 'ID of specific token to retrieve'
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: '550e8400-e29b-41d4-a716-446655440000'
+        - name: object_uuid
+          description: 'ID of specific token to retrieve'
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: '550e8400-e29b-41d4-a716-196655440000'
+      requestBody:
+        description: 'User OIDC access token'
+        content:
+          application/json: 
+            example: 
+              access_token: '{{ACCESS_TOKEN}}'
+        required: true
+      responses:
+        '200':
+          description: 'Successfully retrieve the object'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/likableObject'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '422':
+          $ref: '#/components/responses/MissingParameterError'
+      deprecated: false
+  '/types/{type_uuid}/things/{object_uuid}/like':
+    post:
+      tags:
+        - Like / unlike a likable object and get the like counts
       summary: Like a likable object
       description: 'Like a likable object'
       parameters:
-        - name: type_id
+        - name: type_uuid
           description: 'ID of specific token to retrieve'
           in: path
           required: true
           schema:
             type: string
             format: uuid
-            example: 1
-        - name: object_id
+            example: '550e8400-e29b-41d4-a716-446655440000'
+        - name: object_uuid
           description: 'ID of specific token to retrieve'
           in: path
           required: true
           schema:
             type: string
             format: uuid
-            example: 186734
-      # requestBody:
-      #   description: 'User OIDC access token'
-      #   content:
-      #     text/plain: 
-      #       example: '{{ACCESS_TOKEN}}'
-      #   required: true
+            example: '550e8400-e29b-41d4-a716-196655440000'
+      requestBody:
+        description: 'User OIDC access token'
+        content:
+          application/json: 
+            example: 
+              access_token: '{{ACCESS_TOKEN}}'
+        required: true
       responses:
-        '200':
+        '201':
           description: 'Successfully like the object response'
           content:
             application/json:
@@ -53,38 +96,39 @@ paths:
         '422':
           $ref: '#/components/responses/MissingParameterError'
       deprecated: false
-  '/unlike/types/{type_id}/things/{object_id}':
-    get:
+  '/types/{type_uuid}/things/{object_uuid}/unlike':
+    post:
       tags:
-        - Like / unlike a likable object
+        - Like / unlike a likable object and get the like counts
       summary: Unlike a likable object
       description: 'Unlike a likable object'
       parameters:
-        - name: type_id
+        - name: type_uuid
           description: 'ID of specific token to retrieve'
           in: path
           required: true
           schema:
             type: string
             format: uuid
-            example: 1
-        - name: object_id
+            example: '550e8400-e29b-41d4-a716-446655440000'
+        - name: object_uuid
           description: 'ID of specific token to retrieve'
           in: path
           required: true
           schema:
             type: string
             format: uuid
-            example: 186734
-      # requestBody:
-      #   description: 'User OIDC access token'
-      #   content:
-      #     text/plain: 
-      #       example: '{{ACCESS_TOKEN}}'
-      #   required: true
+            example: '550e8400-e29b-41d4-a716-196655440000'
+      requestBody:
+        description: 'User OIDC access token'
+        content:
+          application/json: 
+            example: 
+              access_token: '{{ACCESS_TOKEN}}'
+        required: true
       responses:
-        '200':
-          description: 'Successfully like the object response'
+        '201':
+          description: 'Successfully unlike the object response'
           content:
             application/json:
               schema:
@@ -92,56 +136,7 @@ paths:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '422':
-          description: 'Missing request parameters'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/likableObject'
-              example:
-                code: 422
-                message: 'object_type is not allowed to be empty'
-      deprecated: false
-  '/info/types/{type_id}/things/{object_id}':
-    get:
-      tags:
-        - Get info on a likable object
-      summary: Get info on a likable object
-      description: 'Get info on a likable object'
-      parameters:
-        - name: type_id
-          description: 'ID of specific token to retrieve'
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            example: 1
-        - name: object_id
-          description: 'ID of specific token to retrieve'
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-            example: 186734
-      responses:
-        '200':
-          description: 'Successfully like the object response'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/likableObject'
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '422':
-          description: 'Missing request parameters'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/likableObject'
-              example:
-                code: 422
-                message: 'object_type is not allowed to be empty'
+          $ref: '#/components/responses/MissingParameterError'
       deprecated: false
   '/types':
     get:
@@ -155,11 +150,11 @@ paths:
           content:
             application/json:
               example:
-                1: countries
-                2: organizations
-                3: planters
-                4: species
-                5: trees
+                550e8400-e29b-41d4-a716-446655440010: countries
+                550e8400-e29b-41d4-a716-446655440001: organizations
+                550e8400-e29b-41d4-a716-446655440019: planters
+                550e8400-e29b-41d4-a716-446655440029: species
+                550e8400-e29b-41d4-a716-446655440024: trees
         '401':
           $ref: '#/components/responses/UnauthorizedError'
       deprecated: false
@@ -171,8 +166,10 @@ paths:
       requestBody:
         description: 'Name of new type'
         content:
-          text/plain: 
-            example: 'trees'
+          application/json: 
+            example: 
+              name: 'trees'
+              access_token: '{{ACCESS_TOKEN}}'
         required: true
       responses:
         '201':
@@ -180,31 +177,32 @@ paths:
           content:
             application/json:
               example:
-                5: 'trees'
+                550e8400-e29b-41d4-a716-446655440019: 'trees'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
       deprecated: false
-  '/types/{type_id}':
-    put:
+  '/types/{type_uuid}':
+    patch:
       tags:
         - Types info and manipulation
       summary: Create a new type in the database
       description: 'Create a new type in the database'
       parameters:
-        - name: type_id
+        - name: type_uuid
           description: 'ID of specific token to retrieve'
           in: path
           required: true
           schema:
             type: string
             format: uuid
-            example: 5
+            example: '550e8400-e29b-41d4-a716-446655440000'
       requestBody:
         description: 'Name of new type'
         content:
-          text/plain: 
+          application/json: 
             example:
-              'above_the_ground_trees'
+              name: 'above_the_ground_trees'
+              access_token: '{{ACCESS_TOKEN}}'
         required: true
       responses:
         '200':
@@ -228,8 +226,9 @@ paths:
       requestBody:
         description: 'User OIDC access token'
         content:
-          text/plain: 
-            example: '{{ACCESS_TOKEN}}'
+          application/json: 
+            example: 
+              access_token: '{{ACCESS_TOKEN}}'
         required: true
       responses:
         '200':
@@ -237,23 +236,15 @@ paths:
           content:
             application/json:
               example:
-                4: [1,2]
-                5: [186735, 186734]
+                550e8400-e29b-41d4-a716-446655440001: [550e8400-e29b-41d4-a716-446655440024,550e8400-e29b-41d4-a716-446655440029]
+                550e8400-e29b-41d4-a716-446655440010: [550e8400-e29b-41d4-a716-446655440019, 550e8400-e29b-41d4-a716-446655440025]
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '404':
           $ref: '#/components/responses/NotfoundError'
       deprecated: false
-
-security:
-  - bearerAuth: []
   
 components:
-  securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
   responses:
     MissingParameterError:
       description: 'Missing request parameters'
@@ -261,7 +252,7 @@ components:
         application/json:
           example:
             code: 422
-            message: 'type_id is not allowed to be empty'
+            message: 'type_uuid is not allowed to be empty'
     UnauthorizedError:
       description: 'Access is missing or invalid'
       content:

--- a/docs/api/spec/query-api.yaml
+++ b/docs/api/spec/query-api.yaml
@@ -12,22 +12,22 @@ servers:
           - dev     # Development server
           - test    # Test server
 paths:
-  '/{object_type}/{object_uuid}/like':
-    post:
+  '/like/types/{type_id}/things/{object_id}':
+    get:
       tags:
         - Like / unlike a likable object
       summary: Like a likable object
       description: 'Like a likable object'
       parameters:
-        - name: object_type
+        - name: type_id
           description: 'ID of specific token to retrieve'
           in: path
           required: true
           schema:
             type: string
             format: uuid
-            example: trees
-        - name: object_uuid
+            example: 1
+        - name: object_id
           description: 'ID of specific token to retrieve'
           in: path
           required: true
@@ -35,46 +35,40 @@ paths:
             type: string
             format: uuid
             example: 186734
-      requestBody:
-        description: 'User OIDC access token'
-        content:
-          text/plain: 
-            example: '{{ACCESS_TOKEN}}'
-        required: true
+      # requestBody:
+      #   description: 'User OIDC access token'
+      #   content:
+      #     text/plain: 
+      #       example: '{{ACCESS_TOKEN}}'
+      #   required: true
       responses:
-        '201':
+        '200':
           description: 'Successfully like the object response'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/likableObject'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '422':
-          description: 'Missing request parameters'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/likableObject'
-              example:
-                code: 422
-                message: 'object_type is not allowed to be empty'
+          $ref: '#/components/responses/MissingParameterError'
       deprecated: false
-  
-  '/{object_type}/{object_uuid}/unlike':
-    post:
+  '/unlike/types/{type_id}/things/{object_id}':
+    get:
       tags:
         - Like / unlike a likable object
       summary: Unlike a likable object
       description: 'Unlike a likable object'
       parameters:
-        - name: object_type
+        - name: type_id
           description: 'ID of specific token to retrieve'
           in: path
           required: true
           schema:
             type: string
             format: uuid
-            example: trees
-        - name: object_uuid
+            example: 1
+        - name: object_id
           description: 'ID of specific token to retrieve'
           in: path
           required: true
@@ -82,19 +76,21 @@ paths:
             type: string
             format: uuid
             example: 186734
-      requestBody:
-        description: 'User OIDC access token'
-        content:
-          text/plain: 
-            example: '{{ACCESS_TOKEN}}'
-        required: true
+      # requestBody:
+      #   description: 'User OIDC access token'
+      #   content:
+      #     text/plain: 
+      #       example: '{{ACCESS_TOKEN}}'
+      #   required: true
       responses:
-        '201':
+        '200':
           description: 'Successfully like the object response'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/likableObject'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '422':
           description: 'Missing request parameters'
           content:
@@ -105,23 +101,22 @@ paths:
                 code: 422
                 message: 'object_type is not allowed to be empty'
       deprecated: false
-      
-  '/{object_type}/{object_uuid}':
+  '/info/types/{type_id}/things/{object_id}':
     get:
       tags:
         - Get info on a likable object
       summary: Get info on a likable object
       description: 'Get info on a likable object'
       parameters:
-        - name: object_type
+        - name: type_id
           description: 'ID of specific token to retrieve'
           in: path
           required: true
           schema:
             type: string
             format: uuid
-            example: trees
-        - name: object_uuid
+            example: 1
+        - name: object_id
           description: 'ID of specific token to retrieve'
           in: path
           required: true
@@ -136,6 +131,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/likableObject'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '422':
           description: 'Missing request parameters'
           content:
@@ -145,6 +142,81 @@ paths:
               example:
                 code: 422
                 message: 'object_type is not allowed to be empty'
+      deprecated: false
+  '/types':
+    get:
+      tags:
+        - Types info and manipulation
+      summary: Get types name and id
+      description: 'Get types name and id'
+      responses:
+        '200':
+          description: 'Successfully retrieve types info'
+          content:
+            application/json:
+              example:
+                1: countries
+                2: organizations
+                3: planters
+                4: species
+                5: trees
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+      deprecated: false
+    post:
+      tags:
+        - Types info and manipulation
+      summary: Create a new type in the database
+      description: 'Create a new type in the database'
+      requestBody:
+        description: 'Name of new type'
+        content:
+          text/plain: 
+            example: 'trees'
+        required: true
+      responses:
+        '201':
+          description: 'Successfully create new type'
+          content:
+            application/json:
+              example:
+                5: 'trees'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+      deprecated: false
+  '/types/{type_id}':
+    put:
+      tags:
+        - Types info and manipulation
+      summary: Create a new type in the database
+      description: 'Create a new type in the database'
+      parameters:
+        - name: type_id
+          description: 'ID of specific token to retrieve'
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 5
+      requestBody:
+        description: 'Name of new type'
+        content:
+          text/plain: 
+            example:
+              'above_the_ground_trees'
+        required: true
+      responses:
+        '200':
+          description: 'Successfully modified the type'
+          content:
+            application/json:
+              example:
+                5: 'above_the_ground_trees'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotfoundError'
       deprecated: false
 
   '/user/likes':
@@ -165,19 +237,45 @@ paths:
           content:
             application/json:
               example:
-                species: [1,2]
-                trees: [186735, 186734]
+                4: [1,2]
+                5: [186735, 186734]
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '404':
-          description: 'User not found'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/likableObject'
-              example:
-                code: 404
-                message: 'User not found'
+          $ref: '#/components/responses/NotfoundError'
       deprecated: false
+
+security:
+  - bearerAuth: []
+  
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  responses:
+    MissingParameterError:
+      description: 'Missing request parameters'
+      content:
+        application/json:
+          example:
+            code: 422
+            message: 'type_id is not allowed to be empty'
+    UnauthorizedError:
+      description: 'Access is missing or invalid'
+      content:
+        application/json:
+          example:
+            code: 401
+            message: 'Access is missing or invalid'
+    NotfoundError:
+      description: 'Not found'
+      content:
+        application/json:
+          example:
+            code: 404
+            message: 'User not found'
   parameters:
     accessToken:
       name: access_token


### PR DESCRIPTION
add routes info in swagger docs as mentioned in #5 

- the user information (id) is included in the body of the post requests
- `patch` method is used instead of `put`
- uuid is used throughout